### PR TITLE
fix scrapinghub/frontera#204

### DIFF
--- a/start-hbase.sh
+++ b/start-hbase.sh
@@ -25,7 +25,7 @@ echo "Updating /etc/hosts to make hbase-docker point to $docker_ip ($docker_host
 if grep 'hbase-docker' /etc/hosts >/dev/null; then
   sudo sed -i .bak "s/^.*hbase-docker.*\$/$docker_ip hbase-docker $docker_hostname/" /etc/hosts
 else
-  sudo sh -c "echo '$docker_ip hbase-docker $docker_hostname' >> /etc/hosts"
+  sudo sh -c "echo '\n$docker_ip hbase-docker $docker_hostname' >> /etc/hosts"
 fi
 
 echo "Now connect to hbase at localhost on the standard ports"


### PR DESCRIPTION
This PR fixes scrapinghub/frontera#204
for some reason  `sudo sh -c "echo '$docker_ip hbase-docker $docker_hostname' >> /etc/hosts"` is not inserting a new line. I tried several other ways of fixing this without adding a `\n`(by adding some flags), but ended up with no luck. Somewhere on stack-overflow though I came across an answer saying that the behavior of `echo` is not standard everywhere. But `\n` worked perfectly here.

I have tested this fix by cloning my fork of `hbase-docker` in my fork of `frontera` and than running the tests on travis. Here's the [build](https://travis-ci.org/voith/frontera/jobs/159168376). Checkout line 441 on the build .
